### PR TITLE
improved handling memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,17 @@ export default nextConfig
 
 ## Cache Strategies
 Explore various caching strategies to find the best fit for your application's needs:
-- **MemoryCache**: Ideal for short-lived data in applications with limited cache size requirements.
+- **MemoryCache**: Ideal for short-lived data in applications with limited cache size requirements. By default limit of size is set to 512MB.
 ```
 import { CacheHandler, MemoryCache } from 'next-cache-handler'
 
 CacheHandler.addStrategy(new MemoryCache())
+```
+```
+import { CacheHandler, MemoryCache } from 'next-cache-handler'
+
+// extending size limitation to 1024MB.
+CacheHandler.addStrategy(new MemoryCache({ sizeLimit: 1024 }))
 ```
 - **FileSystemCache**: Suitable for persistent caching across application restarts.
 ```

--- a/__tests__/memory.spec.ts
+++ b/__tests__/memory.spec.ts
@@ -4,6 +4,7 @@ import { mockCacheEntry } from './mocks'
 const memoryCache = new MemoryCache()
 const cacheKey = 'test'
 const cacheKey2 = 'test-2'
+const sizeOfMockEntry = Buffer.byteLength(JSON.stringify(mockCacheEntry)) / 1024 / 1024
 
 describe('MemoryCache', () => {
   it('should set and read the cache', () => {
@@ -30,5 +31,22 @@ describe('MemoryCache', () => {
 
     expect(memoryCache.get(cacheKey)).toBeFalsy()
     expect(memoryCache.get(cacheKey2)).toBeFalsy()
+  })
+
+  it('should clear data if reached memory limit', () => {
+    const cache = new MemoryCache({ sizeLimit: sizeOfMockEntry * 2 })
+    const overLimitedCacheKey = 'cache-with-overLimited-data'
+
+    cache.set(cacheKey, mockCacheEntry)
+    cache.set(cacheKey2, mockCacheEntry)
+
+    expect(memoryCache.get(cacheKey)).toEqual(mockCacheEntry)
+    expect(memoryCache.get(cacheKey2)).toEqual(mockCacheEntry)
+
+    cache.set(overLimitedCacheKey, mockCacheEntry)
+
+    expect(memoryCache.get(cacheKey)).toBeNull()
+    expect(memoryCache.get(cacheKey2)).toBeNull()
+    expect(memoryCache.get(overLimitedCacheKey)).toEqual(mockCacheEntry)
   })
 })

--- a/src/cacheStrategy/memory.ts
+++ b/src/cacheStrategy/memory.ts
@@ -20,7 +20,7 @@ export class MemoryCache implements CacheStrategy {
     return Buffer.byteLength(JSON.stringify(data)) / 1024 / 1024
   }
 
-  #checkAndValidateSize(data: CacheEntry) {
+  #setAndValidateTotalSize(data: CacheEntry) {
     const currentEntrySize = this.#getItemSizeInMB(data)
     const finalSize = currentEntrySize + this.#totalSize
     const shouldClearCache = finalSize > this.#sizeLimit
@@ -38,7 +38,7 @@ export class MemoryCache implements CacheStrategy {
   }
 
   async set(key: string, data: CacheEntry) {
-    this.#checkAndValidateSize(data)
+    this.#setAndValidateTotalSize(data)
     mapCache.set(key, JSON.stringify(data))
   }
 


### PR DESCRIPTION
- added ability to configure stored size limitation
- clearing data if size limit was exceeded.
- updated tests
- set default cache size to 512MB