### PR TITLE
feat: revalidating tag/path functionality

### DIFF
--- a/examples/app-router/src/app/page.tsx
+++ b/examples/app-router/src/app/page.tsx
@@ -1,5 +1,5 @@
 const getTitle = async () => {
-  const res = await fetch('http://localhost:3000/api')
+  const res = await fetch('http://localhost:3000/api', { next: { tags: ['index'] } })
     .then((r) => r.json())
     .catch(() => ({ title: 'Pregenerated page data.' }))
 

--- a/packages/cache-core/__tests__/fileSystem.spec.ts
+++ b/packages/cache-core/__tests__/fileSystem.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { FileSystemCache } from '../src/'
 import { mockCacheEntry, mockCacheStrategyContext } from './mocks'
 
@@ -11,12 +13,21 @@ const cacheFile2Path = `${mockCacheStrategyContext.serverCacheDirPath}/${cacheKe
 const store = new Map()
 const mockReadFile = jest.fn().mockImplementation((path) => store.get(path))
 const mockWriteFile = jest.fn().mockImplementation((path, data) => store.set(path, data))
-const mockRm = jest.fn().mockImplementation((path) => store.delete(path))
-const mockReaddir = jest
-  .fn()
-  .mockImplementation(() =>
-    [...store.keys()].map((k) => k.replace(`${mockCacheStrategyContext.serverCacheDirPath}/`, ''))
-  )
+const mockRm = jest.fn().mockImplementation((path) => {
+  // @ts-ignore
+  ;[...store.keys()].filter((key) => key.startsWith(path)).forEach((path) => store.delete(path))
+})
+
+const mockReaddir = jest.fn().mockImplementation((path: string, option) =>
+  // @ts-ignore
+  [...store.keys()].map((k) => {
+    if (option) {
+      const name = k.replace(`${path}/`, '').split('/')[0]
+      return { path, name, isDirectory: () => !name?.endsWith('.json') }
+    }
+    return k.replace(`${mockCacheStrategyContext.serverCacheDirPath}/`, '')
+  })
+)
 const mockExistsSync = jest.fn().mockImplementation(() => true)
 
 jest.mock('node:fs/promises', () => {
@@ -86,5 +97,40 @@ describe('FileSystemCache', () => {
     const updatedResult2 = await fileSystemCache.get(cacheKey2, cacheKey2, mockCacheStrategyContext)
     expect(updatedResult1).toBeNull()
     expect(updatedResult2).toBeNull()
+  })
+
+  it('should revalidate cache by tag', async () => {
+    const mockCacheEntryWithTags = { ...mockCacheEntry, tags: [cacheKey] }
+    await fileSystemCache.set(cacheKey, cacheKey, mockCacheEntryWithTags, mockCacheStrategyContext)
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledWith(cacheFilePath, JSON.stringify(mockCacheEntryWithTags))
+
+    const result = await fileSystemCache.get(cacheKey, cacheKey, mockCacheStrategyContext)
+    expect(result).toEqual(mockCacheEntryWithTags)
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
+    expect(mockReadFile).toHaveBeenCalledWith(cacheFilePath, 'utf-8')
+
+    await fileSystemCache.revalidateTag(cacheKey, mockCacheStrategyContext)
+    const updatedResult = await fileSystemCache.get(cacheKey, cacheKey, mockCacheStrategyContext)
+    expect(updatedResult).toBeNull()
+    expect(mockRm).toHaveBeenCalledTimes(1)
+    expect(mockRm).toHaveBeenCalledWith(cacheFilePath)
+  })
+
+  it('should revalidate cache by path', async () => {
+    await fileSystemCache.set(cacheKey, cacheKey, mockCacheEntry, mockCacheStrategyContext)
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledWith(cacheFilePath, JSON.stringify(mockCacheEntry))
+
+    const result = await fileSystemCache.get(cacheKey, cacheKey, mockCacheStrategyContext)
+    expect(result).toEqual(mockCacheEntry)
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
+    expect(mockReadFile).toHaveBeenCalledWith(cacheFilePath, 'utf-8')
+
+    await fileSystemCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`, mockCacheStrategyContext)
+    const updatedResult = await fileSystemCache.get(cacheKey, cacheKey, mockCacheStrategyContext)
+    expect(updatedResult).toBeNull()
+    expect(mockRm).toHaveBeenCalledTimes(1)
+    expect(mockRm).toHaveBeenCalledWith(cacheFilePath.replace(`/${cacheKey}.json`, ''), { recursive: true })
   })
 })

--- a/packages/cache-core/src/cacheHandler.ts
+++ b/packages/cache-core/src/cacheHandler.ts
@@ -176,10 +176,10 @@ export class Cache implements CacheHandler {
       : `tag ${tag}`
     try {
       Cache.logger.info(`Revalidate by ${mode}`)
-      const context = {
+      await Cache.cache.revalidateTag(tag, {
         serverCacheDirPath: this.serverCacheDirPath
-      }
-      return Cache.cache.revalidateTag(tag, context)
+      })
+      return
     } catch (err) {
       Cache.logger.error(`Failed revalidate by ${mode}`, err)
       return

--- a/packages/cache-core/src/cacheHandler.ts
+++ b/packages/cache-core/src/cacheHandler.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import cookieParser from 'cookie'
 import parser from 'ua-parser-js'
 import { pathToRegexp, Path } from 'path-to-regexp'
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import type {
   CacheHandler,
   BaseLogger,
@@ -166,6 +167,22 @@ export class Cache implements CacheHandler {
       }
     } catch (err) {
       Cache.logger.error(`Failed to write cache for ${pageKey}`, err)
+    }
+  }
+
+  async revalidateTag(tag: string) {
+    const mode = tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)
+      ? `path ${tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length)}`
+      : `tag ${tag}`
+    try {
+      Cache.logger.info(`Revalidate by ${mode}`)
+      const context = {
+        serverCacheDirPath: this.serverCacheDirPath
+      }
+      return Cache.cache.revalidateTag(tag, context)
+    } catch (err) {
+      Cache.logger.error(`Failed revalidate by ${mode}`, err)
+      return
     }
   }
 

--- a/packages/cache-core/src/strategies/fileSystem.ts
+++ b/packages/cache-core/src/strategies/fileSystem.ts
@@ -35,7 +35,7 @@ export class FileSystemCache implements CacheStrategy {
 
       if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID) && tag === `${NEXT_CACHE_IMPLICIT_TAG_ID}${pageDirs.name}`) {
         await fs.rm(path.join(pageDirs.path, pageDirs.name), { recursive: true })
-        continue
+        return
       }
 
       const cacheFiles = await fs.readdir(path.join(pageDirs.path, pageDirs.name), { withFileTypes: true })

--- a/packages/cache-core/src/strategies/fileSystem.ts
+++ b/packages/cache-core/src/strategies/fileSystem.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import type { CacheStrategy, CacheEntry, CacheContext } from '@dbbs/next-cache-handler-common'
 
 export class FileSystemCache implements CacheStrategy {
@@ -25,12 +26,38 @@ export class FileSystemCache implements CacheStrategy {
     await fs.writeFile(pathToCacheFile, JSON.stringify(data))
   }
 
+  async revalidateTag(tag: string, ctx: CacheContext): Promise<void> {
+    if (!existsSync(ctx.serverCacheDirPath)) return
+
+    const cacheDir = await fs.readdir(ctx.serverCacheDirPath, { withFileTypes: true })
+    for (const pageDirs of cacheDir) {
+      if (!pageDirs.isDirectory()) continue
+
+      if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID) && tag === `${NEXT_CACHE_IMPLICIT_TAG_ID}${pageDirs.name}`) {
+        await fs.rm(path.join(pageDirs.path, pageDirs.name), { recursive: true })
+        continue
+      }
+
+      const cacheFiles = await fs.readdir(path.join(pageDirs.path, pageDirs.name), { withFileTypes: true })
+      for (const cacheFile of cacheFiles) {
+        if (cacheFile.isDirectory()) continue
+
+        const data = await fs.readFile(path.join(cacheFile.path, cacheFile.name), 'utf-8')
+        const pageData: CacheEntry = JSON.parse(data)
+        if (pageData?.tags?.includes(tag)) {
+          await fs.rm(path.join(cacheFile.path, cacheFile.name))
+        }
+      }
+    }
+    return
+  }
+
   async delete(pageKey: string, cacheKey: string, ctx: CacheContext) {
     await fs.rm(path.join(ctx.serverCacheDirPath, pageKey, `${cacheKey}.json`))
   }
 
   async deleteAllByKeyMatch(pageKey: string, ctx: CacheContext) {
-    const cacheDir = await fs.readdir(path.join(ctx.serverCacheDirPath, 'dataCache'))
+    const cacheDir = await fs.readdir(path.join(ctx.serverCacheDirPath))
     const filesToDelete = cacheDir.filter((fileName: string) => fileName.startsWith(pageKey))
 
     await Promise.allSettled(filesToDelete.map((file) => fs.rm(path.join(ctx.serverCacheDirPath, file))))

--- a/packages/cache-core/src/strategies/memory.ts
+++ b/packages/cache-core/src/strategies/memory.ts
@@ -47,7 +47,7 @@ export class MemoryCache implements CacheStrategy {
     for (const cacheKey of [...mapCache.keys()]) {
       if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID) && tag === `${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`) {
         await this.delete('', cacheKey)
-        continue
+        return
       }
 
       const pageData: CacheEntry = JSON.parse(mapCache.get(cacheKey))

--- a/packages/cache-core/src/strategies/memory.ts
+++ b/packages/cache-core/src/strategies/memory.ts
@@ -47,15 +47,15 @@ export class MemoryCache implements CacheStrategy {
     for (const cacheKey of [...mapCache.keys()]) {
       if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID) && tag === `${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`) {
         await this.delete('', cacheKey)
-        return
+        continue
       }
 
       const pageData: CacheEntry = JSON.parse(mapCache.get(cacheKey))
       if (pageData?.tags?.includes(tag)) {
         await this.delete('', cacheKey)
-        return
       }
     }
+    return
   }
 
   async delete(_pageKey: string, cacheKey: string) {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -25,6 +25,7 @@ export interface CacheStrategy {
   get(pageKey: string, cacheKey: string, ctx: CacheContext): Promise<CacheEntry | null>
   set(pageKey: string, cacheKey: string, data: CacheEntry, ctx: CacheContext): Promise<void>
   delete(pageKey: string, cacheKey: string, ctx: CacheContext): Promise<void>
+  revalidateTag(tag: string, ctx: CacheContext): Promise<void>
   deleteAllByKeyMatch(pageKey: string, ctx: CacheContext): Promise<void>
 }
 
@@ -54,4 +55,5 @@ export declare class CacheHandler {
 
   get(pageKey: string, ctx: CacheHandlerContext): Promise<CacheEntry | null>
   set(pageKey: string, data: IncrementalCacheValue | null, ctx: CacheHandlerContext): Promise<void>
+  revalidateTag(tag: string): Promise<void>
 }


### PR DESCRIPTION
What was done:
- added revalidate tag function to NextCacheHandler
- added revalidating tests for NextCacheHandler
- added revalidate tag function to FileSystemCache
- added revalidating tests for FileSystemCache
- added revalidate tag function to MemoryCache
- added revalidating tests for MemoryCache
- added revalidate tag function to RedisCache
- added revalidating tests for RedisCache
- added revalidate tag function to S3Cache
- added revalidating tests for S3Cache
---
Additional changes: 
- added expiration date to the RedisCache based on the revalidate value 
- added tags to the metadata of S3Cache object 
