### PR TITLE
feat: cache handler revalidate tag functionality

### DIFF
--- a/examples/app-router/src/app/page.tsx
+++ b/examples/app-router/src/app/page.tsx
@@ -1,5 +1,5 @@
 const getTitle = async () => {
-  const res = await fetch('http://localhost:3000/api')
+  const res = await fetch('http://localhost:3000/api', { next: { tags: ['index'] } })
     .then((r) => r.json())
     .catch(() => ({ title: 'Pregenerated page data.' }))
 

--- a/packages/cache-core/__tests__/cacheHandler.spec.ts
+++ b/packages/cache-core/__tests__/cacheHandler.spec.ts
@@ -6,6 +6,7 @@ const mockGetData = jest.fn()
 const mockSetData = jest.fn()
 const mockDeleteData = jest.fn()
 const mockRevalidateTagData = jest.fn()
+const mockDeleteAllByKeyMatchData = jest.fn()
 
 jest.mock('../src/strategies/fileSystem', () => {
   return {
@@ -13,7 +14,8 @@ jest.mock('../src/strategies/fileSystem', () => {
       get: jest.fn((...params) => mockGetData(...params)),
       set: jest.fn((...params) => mockSetData(...params)),
       delete: jest.fn((...params) => mockDeleteData(...params)),
-      revalidateTag: jest.fn((...params) => mockRevalidateTagData(...params))
+      revalidateTag: jest.fn((...params) => mockRevalidateTagData(...params)),
+      deleteAllByKeyMatch: jest.fn((...params) => mockDeleteAllByKeyMatchData(...params))
     }))
   }
 })
@@ -362,12 +364,12 @@ describe('CacheHandler', () => {
     expect(mockLogger.info).toHaveBeenNthCalledWith(1, `Revalidate by tag ${mockCacheKey}`)
 
     expect(mockLogger.error).toHaveBeenCalledTimes(1)
-    expect(mockLogger.error).toHaveBeenCalledWith(`Failed revalidate by tag ${mockCacheKey}`, errorMessage)
+    expect(mockLogger.error).toHaveBeenCalledWith(`Failed revalidate by ${mockCacheKey}`, errorMessage)
   })
 
   it('should log when failed to revalidate path', async () => {
     const errorMessage = 'error revalidate'
-    mockRevalidateTagData.mockRejectedValueOnce(errorMessage)
+    mockDeleteAllByKeyMatchData.mockRejectedValueOnce(errorMessage)
 
     Cache.setCacheStrategy(new FileSystemCache())
     Cache.setLogger(mockLogger)
@@ -379,6 +381,9 @@ describe('CacheHandler', () => {
     expect(mockLogger.info).toHaveBeenNthCalledWith(1, `Revalidate by path ${mockCacheKey}`)
 
     expect(mockLogger.error).toHaveBeenCalledTimes(1)
-    expect(mockLogger.error).toHaveBeenCalledWith(`Failed revalidate by path ${mockCacheKey}`, errorMessage)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      `Failed revalidate by ${NEXT_CACHE_IMPLICIT_TAG_ID}${mockCacheKey}`,
+      errorMessage
+    )
   })
 })

--- a/packages/cache-core/__tests__/cacheHandler.spec.ts
+++ b/packages/cache-core/__tests__/cacheHandler.spec.ts
@@ -1,3 +1,4 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { Cache, FileSystemCache, BaseLogger } from '../src'
 import { mockNextHandlerContext, mockPageData, mockHandlerMethodContext, mockCacheStrategyContext } from './mocks'
 
@@ -372,7 +373,7 @@ describe('CacheHandler', () => {
     Cache.setLogger(mockLogger)
     const cacheHandler = new Cache(mockNextHandlerContext)
 
-    await cacheHandler.revalidateTag(`_N_T_${mockCacheKey}`)
+    await cacheHandler.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${mockCacheKey}`)
 
     expect(mockLogger.info).toHaveBeenCalledTimes(1)
     expect(mockLogger.info).toHaveBeenNthCalledWith(1, `Revalidate by path ${mockCacheKey}`)

--- a/packages/cache-core/__tests__/fileSystem.spec.ts
+++ b/packages/cache-core/__tests__/fileSystem.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { FileSystemCache } from '../src/'
 import { mockCacheEntry, mockCacheStrategyContext } from './mocks'
@@ -13,12 +12,10 @@ const store = new Map()
 const mockReadFile = jest.fn().mockImplementation((path) => store.get(path))
 const mockWriteFile = jest.fn().mockImplementation((path, data) => store.set(path, data))
 const mockRm = jest.fn().mockImplementation((path) => {
-  // @ts-ignore
   ;[...store.keys()].filter((key) => key.startsWith(path)).forEach((path) => store.delete(path))
 })
 
 const mockReaddir = jest.fn().mockImplementation((path: string, option) =>
-  // @ts-ignore
   [...store.keys()].map((k) => {
     if (option) {
       const name = k.replace(`${path}/`, '').split('/')[0]

--- a/packages/cache-core/__tests__/fileSystem.spec.ts
+++ b/packages/cache-core/__tests__/fileSystem.spec.ts
@@ -1,4 +1,3 @@
-import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { FileSystemCache } from '../src/'
 import { mockCacheEntry, mockCacheStrategyContext } from './mocks'
 
@@ -121,7 +120,7 @@ describe('FileSystemCache', () => {
     expect(mockReadFile).toHaveBeenCalledTimes(1)
     expect(mockReadFile).toHaveBeenCalledWith(cacheFilePath, 'utf-8')
 
-    await fileSystemCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`, mockCacheStrategyContext)
+    await fileSystemCache.deleteAllByKeyMatch(cacheKey, mockCacheStrategyContext)
     const updatedResult = await fileSystemCache.get(cacheKey, cacheKey, mockCacheStrategyContext)
     expect(updatedResult).toBeNull()
   })

--- a/packages/cache-core/__tests__/memory.spec.ts
+++ b/packages/cache-core/__tests__/memory.spec.ts
@@ -1,4 +1,3 @@
-import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { MemoryCache } from '../src'
 import { mockCacheEntry } from './mocks'
 
@@ -75,11 +74,11 @@ describe('MemoryCache', () => {
     expect(memoryCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
     expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntry)
 
-    await memoryCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    await memoryCache.deleteAllByKeyMatch(cacheKey)
     expect(memoryCache.get(cacheKey, cacheKey)).toBeFalsy()
     expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntry)
 
-    await memoryCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey2}`)
+    await memoryCache.deleteAllByKeyMatch(cacheKey2)
     expect(memoryCache.get(cacheKey2, cacheKey2)).toBeFalsy()
   })
 })

--- a/packages/cache-core/__tests__/memory.spec.ts
+++ b/packages/cache-core/__tests__/memory.spec.ts
@@ -1,3 +1,4 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { MemoryCache } from '../src'
 import { mockCacheEntry } from './mocks'
 
@@ -16,7 +17,7 @@ describe('MemoryCache', () => {
     memoryCache.set(cacheKey, cacheKey, mockCacheEntry)
     expect(memoryCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
 
-    memoryCache.delete(cacheKey, cacheKey)
+    memoryCache.delete(cacheKey, `${cacheKey}/${cacheKey}`)
     expect(memoryCache.get(cacheKey, cacheKey)).toBeFalsy()
   })
 
@@ -30,6 +31,9 @@ describe('MemoryCache', () => {
     memoryCache.deleteAllByKeyMatch(cacheKey)
 
     expect(memoryCache.get(cacheKey, cacheKey)).toBeFalsy()
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntry)
+
+    memoryCache.deleteAllByKeyMatch(cacheKey2)
     expect(memoryCache.get(cacheKey2, cacheKey2)).toBeFalsy()
   })
 
@@ -48,5 +52,34 @@ describe('MemoryCache', () => {
     expect(memoryCache.get(cacheKey, cacheKey)).toBeNull()
     expect(memoryCache.get(cacheKey2, cacheKey2)).toBeNull()
     expect(memoryCache.get(overLimitedCacheKey, overLimitedCacheKey)).toEqual(mockCacheEntry)
+  })
+
+  it('should revalidate cache by tag', async () => {
+    const mockCacheEntryWithTags = { ...mockCacheEntry, tags: [cacheKey, cacheKey2] }
+    memoryCache.set(cacheKey, cacheKey, mockCacheEntryWithTags)
+    memoryCache.set(cacheKey2, cacheKey2, mockCacheEntryWithTags)
+
+    expect(memoryCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntryWithTags)
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntryWithTags)
+
+    await memoryCache.revalidateTag(cacheKey)
+
+    expect(memoryCache.get(cacheKey, cacheKey)).toBeFalsy()
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toBeFalsy()
+  })
+
+  it('should revalidate cache by path', async () => {
+    memoryCache.set(cacheKey, cacheKey, mockCacheEntry)
+    memoryCache.set(cacheKey2, cacheKey2, mockCacheEntry)
+
+    expect(memoryCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntry)
+
+    await memoryCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    expect(memoryCache.get(cacheKey, cacheKey)).toBeFalsy()
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toEqual(mockCacheEntry)
+
+    await memoryCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey2}`)
+    expect(memoryCache.get(cacheKey2, cacheKey2)).toBeFalsy()
   })
 })

--- a/packages/cache-core/src/cacheHandler.ts
+++ b/packages/cache-core/src/cacheHandler.ts
@@ -175,17 +175,21 @@ export class Cache implements CacheHandler {
   }
 
   async revalidateTag(tag: string) {
-    const mode = tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)
-      ? `path ${tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length)}`
-      : `tag ${tag}`
     try {
-      Cache.logger.info(`Revalidate by ${mode}`)
-      await Cache.cache.revalidateTag(tag, {
-        serverCacheDirPath: this.serverCacheDirPath
-      })
-      return
+      if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
+        const path = tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length)
+        Cache.logger.info(`Revalidate by path ${path}`)
+        await Cache.cache.deleteAllByKeyMatch(path, {
+          serverCacheDirPath: this.serverCacheDirPath
+        })
+      } else {
+        Cache.logger.info(`Revalidate by tag ${tag}`)
+        await Cache.cache.revalidateTag(tag, {
+          serverCacheDirPath: this.serverCacheDirPath
+        })
+      }
     } catch (err) {
-      Cache.logger.error(`Failed revalidate by ${mode}`, err)
+      Cache.logger.error(`Failed revalidate by ${tag}`, err)
       return
     }
   }

--- a/packages/cache-core/src/strategies/fileSystem.ts
+++ b/packages/cache-core/src/strategies/fileSystem.ts
@@ -38,9 +38,9 @@ export class FileSystemCache implements CacheStrategy {
     // Revalidate by Tag
     const recursiveDelete = async (initPath: string = '') => {
       const cacheDir = await fs.readdir(initPath, { withFileTypes: true })
-      for (const { path: itemPath, name: itemName, isDirectory } of cacheDir) {
-        const pathToItem = path.join(itemPath, itemName)
-        if (isDirectory()) {
+      for (const cacheItem of cacheDir) {
+        const pathToItem = path.join(cacheItem.path, cacheItem.name)
+        if (cacheItem.isDirectory()) {
           await recursiveDelete(pathToItem)
           continue
         }

--- a/packages/cache-core/src/strategies/fileSystem.ts
+++ b/packages/cache-core/src/strategies/fileSystem.ts
@@ -29,13 +29,6 @@ export class FileSystemCache implements CacheStrategy {
   async revalidateTag(tag: string, ctx: CacheContext): Promise<void> {
     if (!existsSync(ctx.serverCacheDirPath)) return
 
-    // Revalidate by Path
-    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
-      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length), ctx)
-      return
-    }
-
-    // Revalidate by Tag
     const recursiveDelete = async (initPath: string = '') => {
       const cacheDir = await fs.readdir(initPath, { withFileTypes: true })
       for (const cacheItem of cacheDir) {
@@ -65,6 +58,8 @@ export class FileSystemCache implements CacheStrategy {
   }
 
   async deleteAllByKeyMatch(pageKey: string, ctx: CacheContext) {
+    if (!existsSync(ctx.serverCacheDirPath)) return
+
     const pathToCacheFolder = path.join(ctx.serverCacheDirPath, pageKey)
     if (!existsSync(pathToCacheFolder)) return
 

--- a/packages/cache-core/src/strategies/fileSystem.ts
+++ b/packages/cache-core/src/strategies/fileSystem.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
+import { NEXT_CACHE_IMPLICIT_TAG_ID, NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
 import type { CacheStrategy, CacheEntry, CacheContext } from '@dbbs/next-cache-handler-common'
 
 export class FileSystemCache implements CacheStrategy {
@@ -25,14 +26,56 @@ export class FileSystemCache implements CacheStrategy {
     await fs.writeFile(pathToCacheFile, JSON.stringify(data))
   }
 
+  async revalidateTag(tag: string, ctx: CacheContext): Promise<void> {
+    if (!existsSync(ctx.serverCacheDirPath)) return
+
+    // Revalidate by Path
+    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
+      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length), ctx)
+      return
+    }
+
+    // Revalidate by Tag
+    const recursiveDelete = async (initPath: string = '') => {
+      const cacheDir = await fs.readdir(initPath, { withFileTypes: true })
+      for (const { path: itemPath, name: itemName, isDirectory } of cacheDir) {
+        const pathToItem = path.join(itemPath, itemName)
+        if (isDirectory()) {
+          await recursiveDelete(pathToItem)
+          continue
+        }
+
+        const data = await fs.readFile(pathToItem, 'utf-8')
+        const pageData: CacheEntry = JSON.parse(data)
+        if (
+          pageData?.tags?.includes(tag) ||
+          (pageData.value?.kind === 'PAGE' &&
+            pageData.value.headers?.[NEXT_CACHE_TAGS_HEADER]?.toString()?.split(',').includes(tag))
+        ) {
+          await fs.rm(pathToItem)
+        }
+      }
+    }
+    await recursiveDelete(ctx.serverCacheDirPath)
+    return
+  }
+
   async delete(pageKey: string, cacheKey: string, ctx: CacheContext) {
     await fs.rm(path.join(ctx.serverCacheDirPath, pageKey, `${cacheKey}.json`))
   }
 
   async deleteAllByKeyMatch(pageKey: string, ctx: CacheContext) {
-    const cacheDir = await fs.readdir(path.join(ctx.serverCacheDirPath, 'dataCache'))
-    const filesToDelete = cacheDir.filter((fileName: string) => fileName.startsWith(pageKey))
+    const pathToCacheFolder = path.join(ctx.serverCacheDirPath, pageKey)
+    if (!existsSync(pathToCacheFolder)) return
 
-    await Promise.allSettled(filesToDelete.map((file) => fs.rm(path.join(ctx.serverCacheDirPath, file))))
+    const cacheDir = await fs.readdir(pathToCacheFolder, { withFileTypes: true })
+    const filesToDelete = cacheDir.filter((cacheItem) => !cacheItem.isDirectory())
+
+    if (cacheDir.length === filesToDelete.length) {
+      await fs.rm(pathToCacheFolder, { recursive: true })
+      return
+    }
+
+    await Promise.allSettled(filesToDelete.map((file) => fs.rm(path.join(file.path, file.name))))
   }
 }

--- a/packages/cache-core/src/strategies/memory.ts
+++ b/packages/cache-core/src/strategies/memory.ts
@@ -44,13 +44,6 @@ export class MemoryCache implements CacheStrategy {
   }
 
   async revalidateTag(tag: string): Promise<void> {
-    // Revalidate by Path
-    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
-      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
-      return
-    }
-
-    // Revalidate by Tag
     for (const cacheKey of [...mapCache.keys()]) {
       const pageData: CacheEntry = JSON.parse(mapCache.get(cacheKey))
       if (

--- a/packages/cache-core/src/strategies/memory.ts
+++ b/packages/cache-core/src/strategies/memory.ts
@@ -1,3 +1,4 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID, NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
 import type { CacheEntry, CacheStrategy } from '@dbbs/next-cache-handler-common'
 
 const mapCache = new Map()
@@ -32,14 +33,35 @@ export class MemoryCache implements CacheStrategy {
     this.#totalSize = shouldClearCache ? currentEntrySize : finalSize
   }
 
-  get(_pageKey: string, cacheKey: string) {
-    const data = mapCache.get(cacheKey)
+  get(pageKey: string, cacheKey: string) {
+    const data = mapCache.get(`${pageKey}/${cacheKey}`)
     return data ? JSON.parse(data) : null
   }
 
-  async set(_pageKey: string, cacheKey: string, data: CacheEntry) {
+  async set(pageKey: string, cacheKey: string, data: CacheEntry) {
     this.#setAndValidateTotalSize(data)
-    mapCache.set(cacheKey, JSON.stringify(data))
+    mapCache.set(`${pageKey}/${cacheKey}`, JSON.stringify(data))
+  }
+
+  async revalidateTag(tag: string): Promise<void> {
+    // Revalidate by Path
+    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
+      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
+      return
+    }
+
+    // Revalidate by Tag
+    for (const cacheKey of [...mapCache.keys()]) {
+      const pageData: CacheEntry = JSON.parse(mapCache.get(cacheKey))
+      if (
+        pageData?.tags?.includes(tag) ||
+        (pageData?.value?.kind === 'PAGE' &&
+          pageData.value?.headers?.[NEXT_CACHE_TAGS_HEADER]?.toString()?.split(',').includes(tag))
+      ) {
+        await this.delete('', cacheKey)
+      }
+    }
+    return
   }
 
   async delete(_pageKey: string, cacheKey: string) {
@@ -50,9 +72,13 @@ export class MemoryCache implements CacheStrategy {
   }
 
   async deleteAllByKeyMatch(pageKey: string) {
-    const allKeys = [...mapCache.keys()]
+    const allKeys: string[] = [...mapCache.keys()]
 
-    allKeys.forEach((cacheKey) => {
+    const relatedKeys = allKeys.filter(
+      (key) => key.startsWith(pageKey) && key.replace(`${pageKey}/`, '').split('/').length === 1
+    )
+
+    relatedKeys.forEach((cacheKey) => {
       if (cacheKey.startsWith(pageKey)) {
         this.delete(pageKey, cacheKey)
       }

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -25,6 +25,7 @@ export interface CacheStrategy {
   get(pageKey: string, cacheKey: string, ctx: CacheContext): Promise<CacheEntry | null>
   set(pageKey: string, cacheKey: string, data: CacheEntry, ctx: CacheContext): Promise<void>
   delete(pageKey: string, cacheKey: string, ctx: CacheContext): Promise<void>
+  revalidateTag(tag: string, ctx: CacheContext): Promise<void>
   deleteAllByKeyMatch(pageKey: string, ctx: CacheContext): Promise<void>
 }
 
@@ -54,4 +55,5 @@ export declare class CacheHandler {
 
   get(pageKey: string, ctx: CacheHandlerContext): Promise<CacheEntry | null>
   set(pageKey: string, data: IncrementalCacheValue | null, ctx: CacheHandlerContext): Promise<void>
+  revalidateTag(tag: string): Promise<void>
 }

--- a/packages/redis-cache/__tests__/redis.spec.ts
+++ b/packages/redis-cache/__tests__/redis.spec.ts
@@ -1,6 +1,5 @@
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { RedisCache } from '../src'
-import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 
 export const mockCacheEntry: CacheEntry = {
   value: {
@@ -103,7 +102,7 @@ describe('RedisCache', () => {
 
     expect(await redisCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
 
-    await redisCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    await redisCache.deleteAllByKeyMatch(cacheKey)
     expect(redisCache.client.del).toHaveBeenCalledTimes(1)
     expect(redisCache.client.del).toHaveBeenNthCalledWith(1, `${cacheKey}//${cacheKey}`)
 

--- a/packages/redis-cache/__tests__/redis.spec.ts
+++ b/packages/redis-cache/__tests__/redis.spec.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { RedisCache } from '../src'
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 
 export const mockCacheEntry: CacheEntry = {
   value: {
@@ -14,6 +16,8 @@ export const mockCacheEntry: CacheEntry = {
 }
 
 const store = new Map()
+// @ts-ignore
+const mockGetKeys = jest.fn().mockImplementation(() => [...store.keys()])
 const mockReadKey = jest.fn().mockImplementation((path) => store.get(path))
 const mockWriteKey = jest.fn().mockImplementation((path, data) => store.set(path, data))
 const mockDeleteKey = jest.fn().mockImplementation((path) => store.delete(path))
@@ -22,10 +26,11 @@ jest.mock('redis', () => {
   return {
     createClient: jest.fn().mockReturnValue({
       connect: jest.fn(),
+      keys: jest.fn((...params) => mockGetKeys(...params)),
       get: jest.fn((...params) => mockReadKey(...params)),
       set: jest.fn((...params) => mockWriteKey(...params)),
       del: jest.fn((...params) => mockDeleteKey(...params)),
-      scanIterator: jest.fn().mockImplementation(() => store.keys())
+      scan: jest.fn().mockImplementation(() => ({ cursor: 0, keys: store.keys() }))
     })
   }
 })
@@ -44,48 +49,66 @@ describe('RedisCache', () => {
   it('should set and read the cache', async () => {
     await redisCache.set(cacheKey, cacheKey, mockCacheEntry)
     expect(redisCache.client.set).toHaveBeenCalledTimes(1)
-    expect(redisCache.client.set).toHaveBeenCalledWith(cacheKey, JSON.stringify(mockCacheEntry))
+    expect(redisCache.client.set).toHaveBeenCalledWith(`${cacheKey}//${cacheKey}`, JSON.stringify(mockCacheEntry), {})
 
     const result = await redisCache.get(cacheKey, cacheKey)
     expect(result).toEqual(mockCacheEntry)
     expect(redisCache.client.get).toHaveBeenCalledTimes(1)
-    expect(redisCache.client.get).toHaveBeenCalledWith(cacheKey)
+    expect(redisCache.client.get).toHaveBeenCalledWith(`${cacheKey}//${cacheKey}`)
   })
 
   it('should delete cache value', async () => {
     await redisCache.set(cacheKey, cacheKey, mockCacheEntry)
     expect(redisCache.client.set).toHaveBeenCalledTimes(1)
-    expect(redisCache.client.set).toHaveBeenCalledWith(cacheKey, JSON.stringify(mockCacheEntry))
+    expect(redisCache.client.set).toHaveBeenCalledWith(`${cacheKey}//${cacheKey}`, JSON.stringify(mockCacheEntry), {})
 
     const result = await redisCache.get(cacheKey, cacheKey)
     expect(result).toEqual(mockCacheEntry)
     expect(redisCache.client.get).toHaveBeenCalledTimes(1)
-    expect(redisCache.client.get).toHaveBeenCalledWith(cacheKey)
+    expect(redisCache.client.get).toHaveBeenCalledWith(`${cacheKey}//${cacheKey}`)
 
     await redisCache.delete(cacheKey, cacheKey)
     const updatedResult = await redisCache.get(cacheKey, cacheKey)
     expect(updatedResult).toBeNull()
     expect(redisCache.client.del).toHaveBeenCalledTimes(1)
-    expect(redisCache.client.del).toHaveBeenCalledWith(cacheKey)
+    expect(redisCache.client.del).toHaveBeenCalledWith(`${cacheKey}//${cacheKey}`)
   })
 
   it('should delete all cache entries by key match', async () => {
     await redisCache.set(cacheKey, cacheKey, mockCacheEntry)
-    await redisCache.set(cacheKey2, cacheKey2, mockCacheEntry)
 
     const result1 = await redisCache.get(cacheKey, cacheKey)
-    const result2 = await redisCache.get(cacheKey2, cacheKey2)
     expect(result1).toEqual(mockCacheEntry)
-    expect(result2).toEqual(mockCacheEntry)
 
     await redisCache.deleteAllByKeyMatch(cacheKey)
-    expect(redisCache.client.del).toHaveBeenCalledTimes(2)
-    expect(redisCache.client.del).toHaveBeenNthCalledWith(1, cacheKey)
-    expect(redisCache.client.del).toHaveBeenNthCalledWith(2, cacheKey2)
+    expect(redisCache.client.del).toHaveBeenCalledTimes(1)
+    expect(redisCache.client.del).toHaveBeenNthCalledWith(1, `${cacheKey}//${cacheKey}`)
 
-    const updatedResult1 = await redisCache.get(cacheKey, cacheKey)
-    const updatedResult2 = await redisCache.get(cacheKey2, cacheKey)
-    expect(updatedResult1).toBeNull()
-    expect(updatedResult2).toBeNull()
+    expect(await redisCache.get(cacheKey, cacheKey)).toBeNull()
+  })
+
+  it('should revalidate cache by tag', async () => {
+    const mockCacheEntryWithTags = { ...mockCacheEntry, tags: [cacheKey, cacheKey2] }
+    await redisCache.set(cacheKey, cacheKey, mockCacheEntryWithTags)
+
+    expect(await redisCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntryWithTags)
+
+    await redisCache.revalidateTag(cacheKey)
+    expect(redisCache.client.del).toHaveBeenCalledTimes(1)
+    expect(redisCache.client.del).toHaveBeenNthCalledWith(1, `${cacheKey}//${cacheKey}`)
+
+    expect(await redisCache.get(cacheKey, cacheKey)).toBeNull()
+  })
+
+  it('should revalidate cache by path', async () => {
+    await redisCache.set(cacheKey, cacheKey, mockCacheEntry)
+
+    expect(await redisCache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
+
+    await redisCache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    expect(redisCache.client.del).toHaveBeenCalledTimes(1)
+    expect(redisCache.client.del).toHaveBeenNthCalledWith(1, `${cacheKey}//${cacheKey}`)
+
+    expect(await redisCache.get(cacheKey, cacheKey)).toBeNull()
   })
 })

--- a/packages/redis-cache/__tests__/redis.spec.ts
+++ b/packages/redis-cache/__tests__/redis.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { RedisCache } from '../src'
 import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
@@ -16,7 +15,6 @@ export const mockCacheEntry: CacheEntry = {
 }
 
 const store = new Map()
-// @ts-ignore
 const mockGetKeys = jest.fn().mockImplementation(() => [...store.keys()])
 const mockReadKey = jest.fn().mockImplementation((path) => store.get(path))
 const mockWriteKey = jest.fn().mockImplementation((path, data) => store.set(path, data))

--- a/packages/redis-cache/src/index.ts
+++ b/packages/redis-cache/src/index.ts
@@ -23,13 +23,6 @@ export class RedisCache implements CacheStrategy {
   }
 
   async revalidateTag(tag: string): Promise<void> {
-    // Revalidate by Path
-    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
-      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
-      return
-    }
-
-    // Revalidate by Tag
     let cursor = 0
     do {
       const { cursor: currentCursor, keys } = await this.client.scan(0, { MATCH: '*', COUNT: 100 })

--- a/packages/redis-cache/src/index.ts
+++ b/packages/redis-cache/src/index.ts
@@ -1,3 +1,4 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID, NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
 import { createClient, RedisClientType, RedisClientOptions } from 'redis'
 import type { CacheEntry, CacheStrategy } from '@dbbs/next-cache-handler-common'
 
@@ -9,25 +10,59 @@ export class RedisCache implements CacheStrategy {
     this.client.connect()
   }
 
-  async get(_pageKey: string, cacheKey: string): Promise<CacheEntry | null> {
-    const pageData = await this.client.get(cacheKey)
+  async get(pageKey: string, cacheKey: string): Promise<CacheEntry | null> {
+    const pageData = await this.client.get(`${pageKey}//${cacheKey}`)
     if (!pageData) return null
     return JSON.parse(pageData)
   }
 
-  async set(_pageKey: string, cacheKey: string, data: CacheEntry): Promise<void> {
-    await this.client.set(cacheKey, JSON.stringify(data))
+  async set(pageKey: string, cacheKey: string, data: CacheEntry): Promise<void> {
+    await this.client.set(`${pageKey}//${cacheKey}`, JSON.stringify(data), {
+      ...(data.revalidate ? { EX: Number(data.revalidate) } : undefined)
+    })
   }
 
-  async delete(_pageKey: string, cacheKey: string): Promise<void> {
-    await this.client.del(cacheKey)
+  async revalidateTag(tag: string): Promise<void> {
+    // Revalidate by Path
+    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
+      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
+      return
+    }
+
+    // Revalidate by Tag
+    let cursor = 0
+    do {
+      const { cursor: currentCursor, keys } = await this.client.scan(0, { MATCH: '*', COUNT: 100 })
+      cursor = currentCursor
+      for (const cacheKey of keys) {
+        const data = await this.client.get(cacheKey)
+        if (!data) continue
+
+        const pageData: CacheEntry | null = JSON.parse(data)
+        if (
+          pageData?.tags?.includes(tag) ||
+          (pageData?.value?.kind === 'PAGE' &&
+            pageData.value?.headers?.[NEXT_CACHE_TAGS_HEADER]?.toString()?.split(',').includes(tag))
+        ) {
+          await this.client.del(cacheKey)
+        }
+      }
+    } while (cursor)
+    return
+  }
+
+  async delete(pageKey: string, cacheKey: string): Promise<void> {
+    await this.client.del(`${pageKey}//${cacheKey}`)
   }
 
   async deleteAllByKeyMatch(key: string): Promise<void> {
-    const allKeys = this.client.scanIterator({ MATCH: key })
-
-    for await (const cacheKey of allKeys) {
-      this.client.del(cacheKey)
-    }
+    let cursor = 0
+    do {
+      const result = await this.client.scan(0, { MATCH: `${key}//*`, COUNT: 100 })
+      cursor = result.cursor
+      for await (const cacheKey of result.keys) {
+        await this.client.del(cacheKey)
+      }
+    } while (cursor != 0)
   }
 }

--- a/packages/s3-cache/__tests__/s3.spec.ts
+++ b/packages/s3-cache/__tests__/s3.spec.ts
@@ -121,17 +121,6 @@ describe('S3Cache', () => {
     })
   })
 
-  it('should revalidate cache by tag', async () => {
-    const mockCacheEntryWithTags = { ...mockCacheEntry, tags: [cacheKey] }
-    await s3Cache.set(cacheKey, cacheKey, mockCacheEntryWithTags)
-
-    expect(await s3Cache.get(cacheKey, cacheKey)).toEqual(mockCacheEntryWithTags)
-
-    await s3Cache.revalidateTag(cacheKey)
-
-    expect(await s3Cache.get(cacheKey, cacheKey)).toBeNull()
-  })
-
   it('should revalidate cache by path', async () => {
     await s3Cache.set(cacheKey, cacheKey, mockCacheEntry)
 

--- a/packages/s3-cache/__tests__/s3.spec.ts
+++ b/packages/s3-cache/__tests__/s3.spec.ts
@@ -1,4 +1,3 @@
-import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { S3Cache } from '../src'
 
@@ -138,7 +137,7 @@ describe('S3Cache', () => {
 
     expect(await s3Cache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
 
-    await s3Cache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    await s3Cache.deleteAllByKeyMatch(cacheKey)
     expect(await s3Cache.get(cacheKey, cacheKey)).toBeNull()
   })
 })

--- a/packages/s3-cache/__tests__/s3.spec.ts
+++ b/packages/s3-cache/__tests__/s3.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { S3Cache } from '../src'
 
@@ -16,12 +18,20 @@ export const mockCacheEntry: CacheEntry = {
 }
 
 const store = new Map()
-const mockGetObject = jest.fn().mockImplementation(({ Key }) => {
+const mockGetObject = jest.fn().mockImplementation(async ({ Key }) => {
   const res = store.get(Key)
-  return res ? { Body: { transformToString: () => res } } : { Body: undefined }
+  return res
+    ? { Body: { transformToString: () => res.Body }, Metadata: res.Metadata }
+    : { Body: undefined, Metadata: undefined }
 })
-const mockPutObject = jest.fn().mockImplementation(({ Key, Body }) => store.set(Key, Body))
-const mockDeleteObject = jest.fn().mockImplementation(({ Key }) => store.delete(Key))
+const mockPutObject = jest
+  .fn()
+  .mockImplementation(async ({ Key, Body, Metadata }) => store.set(Key, { Body, Metadata }))
+const mockDeleteObject = jest.fn().mockImplementation(async ({ Key }) => store.delete(Key))
+const mockGetObjectList = jest
+  .fn()
+  // @ts-ignore
+  .mockImplementation(async () => ({ Contents: [...store.keys()].map((key) => ({ Key: key })) }))
 
 jest.mock('@dbbs/next-cache-handler-common', () => ({
   ...jest.requireActual('@dbbs/next-cache-handler-common'),
@@ -37,6 +47,7 @@ jest.mock('@aws-sdk/client-s3', () => {
       getObject: jest.fn((...params) => mockGetObject(...params)),
       putObject: jest.fn((...params) => mockPutObject(...params)),
       deleteObject: jest.fn((...params) => mockDeleteObject(...params)),
+      listObjectsV2: jest.fn((...params) => mockGetObjectList(...params)),
       config: {}
     })
   }
@@ -102,10 +113,34 @@ describe('S3Cache', () => {
     await s3Cache.delete(cacheKey, cacheKey)
     const updatedResult = await s3Cache.get(cacheKey, cacheKey)
     expect(updatedResult).toBeNull()
-    expect(s3Cache.client.deleteObject).toHaveBeenCalledTimes(1)
-    expect(s3Cache.client.deleteObject).toHaveBeenCalledWith({
+    expect(s3Cache.client.deleteObject).toHaveBeenCalledTimes(2)
+    expect(s3Cache.client.deleteObject).toHaveBeenNthCalledWith(1, {
       Bucket: mockBucketName,
       Key: `${cacheKey}/${cacheKey}.json`
     })
+    expect(s3Cache.client.deleteObject).toHaveBeenNthCalledWith(2, {
+      Bucket: mockBucketName,
+      Key: `${cacheKey}/${cacheKey}.html`
+    })
+  })
+
+  it('should revalidate cache by tag', async () => {
+    const mockCacheEntryWithTags = { ...mockCacheEntry, tags: [cacheKey] }
+    await s3Cache.set(cacheKey, cacheKey, mockCacheEntryWithTags)
+
+    expect(await s3Cache.get(cacheKey, cacheKey)).toEqual(mockCacheEntryWithTags)
+
+    await s3Cache.revalidateTag(cacheKey)
+
+    expect(await s3Cache.get(cacheKey, cacheKey)).toBeNull()
+  })
+
+  it('should revalidate cache by path', async () => {
+    await s3Cache.set(cacheKey, cacheKey, mockCacheEntry)
+
+    expect(await s3Cache.get(cacheKey, cacheKey)).toEqual(mockCacheEntry)
+
+    await s3Cache.revalidateTag(`${NEXT_CACHE_IMPLICIT_TAG_ID}${cacheKey}`)
+    expect(await s3Cache.get(cacheKey, cacheKey)).toBeNull()
   })
 })

--- a/packages/s3-cache/__tests__/s3.spec.ts
+++ b/packages/s3-cache/__tests__/s3.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { NEXT_CACHE_IMPLICIT_TAG_ID } from 'next/dist/lib/constants'
 import { CacheEntry } from '@dbbs/next-cache-handler-common'
 import { S3Cache } from '../src'
@@ -30,7 +29,6 @@ const mockPutObject = jest
 const mockDeleteObject = jest.fn().mockImplementation(async ({ Key }) => store.delete(Key))
 const mockGetObjectList = jest
   .fn()
-  // @ts-ignore
   .mockImplementation(async () => ({ Contents: [...store.keys()].map((key) => ({ Key: key })) }))
 
 jest.mock('@dbbs/next-cache-handler-common', () => ({

--- a/packages/s3-cache/src/index.ts
+++ b/packages/s3-cache/src/index.ts
@@ -1,5 +1,9 @@
-import { S3 } from '@aws-sdk/client-s3'
+import { NEXT_CACHE_IMPLICIT_TAG_ID, NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
+import { ListObjectsV2CommandOutput, S3 } from '@aws-sdk/client-s3'
 import { getAWSCredentials, type CacheEntry, type CacheStrategy } from '@dbbs/next-cache-handler-common'
+
+const TAGS_SEPARATOR = ','
+const NOT_FOUND_ERROR = ['NotFound', 'NoSuchKey']
 
 export class S3Cache implements CacheStrategy {
   public readonly client: S3
@@ -16,20 +20,16 @@ export class S3Cache implements CacheStrategy {
     this.bucketName = bucketName
   }
 
-  removeSlashFromStart(value: string) {
-    return value.replace('/', '')
-  }
-
   async get(pageKey: string, cacheKey: string): Promise<CacheEntry | null> {
     if (!this.client) return null
 
     const pageData = await this.client
       .getObject({
         Bucket: this.bucketName,
-        Key: `${this.removeSlashFromStart(pageKey)}/${cacheKey}.json`
+        Key: `${pageKey}/${cacheKey}.json`
       })
       .catch((error) => {
-        if (error.name === 'NotFound' || error.name === 'NoSuchKey') return null
+        if (NOT_FOUND_ERROR.includes(error.name)) return null
         throw error
       })
 
@@ -39,33 +39,97 @@ export class S3Cache implements CacheStrategy {
   }
 
   async set(pageKey: string, cacheKey: string, data: CacheEntry): Promise<void> {
-    if (data.value?.kind === 'PAGE') {
-      await this.client.putObject({
-        Bucket: this.bucketName,
-        Key: `${this.removeSlashFromStart(pageKey)}/${cacheKey}.html`,
-        Body: data.value.html
-      })
+    const input = {
+      Bucket: this.bucketName,
+      Key: `${pageKey}/${cacheKey}`,
+      ...(data.tags?.length ? { Metadata: { tags: data.tags.join(TAGS_SEPARATOR) } } : {})
     }
 
-    await this.client.putObject({
-      Bucket: this.bucketName,
-      Key: `${this.removeSlashFromStart(pageKey)}/${cacheKey}.json`,
-      Body: JSON.stringify(data)
-    })
+    if (data.value?.kind === 'PAGE') {
+      await this.client.putObject({ ...input, Key: `${input.Key}.html`, Body: data.value.html })
+    }
+
+    await this.client.putObject({ ...input, Key: `${input.Key}.json`, Body: JSON.stringify(data) })
+  }
+
+  async revalidateTag(tag: string): Promise<void> {
+    // Revalidate by Path
+    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
+      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
+      return
+    }
+
+    // Revalidate by Tag
+    let nextContinuationToken: string | undefined = undefined
+    do {
+      const { Contents: contents = [], NextContinuationToken: token }: ListObjectsV2CommandOutput =
+        await this.client.listObjectsV2({
+          Bucket: this.bucketName,
+          ContinuationToken: nextContinuationToken
+        })
+      nextContinuationToken = token
+
+      for (const { Key: key } of contents) {
+        if (!key) continue
+
+        const args = { Bucket: this.bucketName, Key: key }
+        const { Metadata: metadata = {}, Body: body } = await this.client.getObject(args)
+
+        const { tags = '' } = metadata
+        if (!!tags && tags.split(TAGS_SEPARATOR).includes(tag)) {
+          const lastSlashIndex = key.lastIndexOf('/')
+          await this.delete(
+            key.substring(0, lastSlashIndex),
+            key.substring(lastSlashIndex + 1).replace(/\.json$|\.html$/, '')
+          )
+          continue
+        }
+
+        if (key.endsWith('.json') && body) {
+          const { value }: CacheEntry = JSON.parse(await body.transformToString('utf-8'))
+          if (value?.kind === 'PAGE' && value.headers?.[NEXT_CACHE_TAGS_HEADER]?.toString()?.split(',').includes(tag)) {
+            const lastSlashIndex = key.lastIndexOf('/')
+            await this.delete(
+              key.substring(0, lastSlashIndex),
+              key.substring(lastSlashIndex + 1).replace(/\.json$|\.html$/, '')
+            )
+          }
+        }
+      }
+    } while (nextContinuationToken)
+    return
   }
 
   async delete(pageKey: string, cacheKey: string): Promise<void> {
-    await this.client.deleteObject({
-      Bucket: this.bucketName,
-      Key: `${this.removeSlashFromStart(pageKey)}/${cacheKey}.json`
+    await this.client.deleteObject({ Bucket: this.bucketName, Key: `${pageKey}/${cacheKey}.json` }).catch((error) => {
+      if (NOT_FOUND_ERROR.includes(error.name)) return null
+      throw error
     })
-    // TODO extend cache context and add value type to drop s3 html page
+    await this.client.deleteObject({ Bucket: this.bucketName, Key: `${pageKey}/${cacheKey}.html` }).catch((error) => {
+      if (NOT_FOUND_ERROR.includes(error.name)) return null
+      throw error
+    })
   }
 
   async deleteAllByKeyMatch(pageKey: string): Promise<void> {
-    await this.client.deleteObject({
-      Bucket: this.bucketName,
-      Key: `${this.removeSlashFromStart(pageKey)}/`
-    })
+    let nextContinuationToken: string | undefined = undefined
+    do {
+      const { Contents: contents = [], NextContinuationToken: token }: ListObjectsV2CommandOutput =
+        await this.client.listObjectsV2({
+          Bucket: this.bucketName,
+          ContinuationToken: nextContinuationToken,
+          Prefix: `${pageKey}/`,
+          Delimiter: '/'
+        })
+      nextContinuationToken = token
+
+      for (const { Key: key } of contents) {
+        if (!key) continue
+        if (key.endsWith('.json') || key.endsWith('.html')) {
+          await this.client.deleteObject({ Bucket: this.bucketName, Key: key })
+        }
+      }
+    } while (nextContinuationToken)
+    return
   }
 }

--- a/packages/s3-cache/src/index.ts
+++ b/packages/s3-cache/src/index.ts
@@ -1,4 +1,4 @@
-import { NEXT_CACHE_IMPLICIT_TAG_ID, NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
+import { NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
 import { ListObjectsV2CommandOutput, S3 } from '@aws-sdk/client-s3'
 import { getAWSCredentials, type CacheEntry, type CacheStrategy } from '@dbbs/next-cache-handler-common'
 
@@ -53,13 +53,6 @@ export class S3Cache implements CacheStrategy {
   }
 
   async revalidateTag(tag: string): Promise<void> {
-    // Revalidate by Path
-    if (tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID)) {
-      await this.deleteAllByKeyMatch(tag.slice(NEXT_CACHE_IMPLICIT_TAG_ID.length))
-      return
-    }
-
-    // Revalidate by Tag
     let nextContinuationToken: string | undefined = undefined
     do {
       const { Contents: contents = [], NextContinuationToken: token }: ListObjectsV2CommandOutput =


### PR DESCRIPTION
What was done:

- added revalidate tag function to NextCacheHandler
- added revalidating tests for NextCacheHandler
- added revalidate tag function to FileSystemCache
- added revalidating tests for FileSystemCache
- added revalidate tag function to MemoryCache
- added revalidating tests for MemoryCache
- added revalidate tag function to RedisCache
- added revalidating tests for RedisCache
- added revalidate tag function to S3Cache
- added revalidating tests for S3Cache
---
Additional changes:

- added expiration date to the RedisCache based on the revalidate value
- added tags to the metadata of S3Cache object