### PR TITLE
fix: set ttl for redis record

### DIFF
--- a/packages/redis-cache/src/RedisStack.ts
+++ b/packages/redis-cache/src/RedisStack.ts
@@ -60,13 +60,11 @@ export class RedisStack implements RedisAdapter {
         : ''
     const generalTags = [headersTags, data?.tags?.join(SEPARATOR)].filter(Boolean).join(SEPARATOR)
 
-    const cacheData = {
-      ...data,
-      ...(data.revalidate && { EX: Number(data.revalidate) }),
-      currentCacheKey: cacheKey,
-      generalTags
-    }
+    const cacheData = { ...data, currentCacheKey: cacheKey, generalTags }
     await this.client.json.set(`${pageKey}//${cacheKey}`, '.', cacheData as unknown as RedisJSON)
+    if (data.revalidate) {
+      await this.client.expire(`${pageKey}//${cacheKey}`, Number(data.revalidate))
+    }
   }
 
   async findCacheKeys(tag: string, cacheKeys: string[]): Promise<string[]> {


### PR DESCRIPTION
In case when we use [JSON SET](https://redis.io/docs/latest/commands/json.set/) we can't set ttl, let's use [EXPIRE](https://redis.io/docs/latest/commands/expire/) for this case 