### PR TITLE
(bug/Logger-58): fixed exporting types for logger

### DIFF
--- a/packages/cache-core/src/index.ts
+++ b/packages/cache-core/src/index.ts
@@ -1,4 +1,4 @@
 export { Cache } from './cacheHandler'
 export { FileSystemCache } from './strategies/fileSystem'
 export { MemoryCache, type MemoryCacheConstructorProps } from './strategies/memory'
-export * from '@dbbs/next-cache-handler-common'
+export type { LoggerInputParams, BaseLogger } from './logger'

--- a/packages/cache-core/src/logger/index.ts
+++ b/packages/cache-core/src/logger/index.ts
@@ -1,4 +1,9 @@
-import { BaseLogger, LoggerInputParams } from '@dbbs/next-cache-handler-common'
+export type LoggerInputParams = Parameters<typeof console.log>
+
+export interface BaseLogger {
+  info(...params: LoggerInputParams): void
+  error(...params: LoggerInputParams): void
+}
 
 export class ConsoleLogger implements BaseLogger {
   constructor() {}

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -3,13 +3,6 @@ import type { CacheHandlerContext as NextCacheHandlerContext } from 'next/dist/s
 
 export { NextCacheHandlerContext, IncrementalCacheValue, IncrementalCacheKindHint }
 
-export type LoggerInputParams = Parameters<typeof console.log>
-
-export interface BaseLogger {
-  info(...params: LoggerInputParams): void
-  error(...params: LoggerInputParams): void
-}
-
 export interface CacheEntry {
   value: IncrementalCacheValue | null
   lastModified: number // time when data was saved


### PR DESCRIPTION
- moved logger types to cache core package instead of the common